### PR TITLE
Allows metadata upload to dataset having different UUID 

### DIFF
--- a/geonode/layers/api/tests.py
+++ b/geonode/layers/api/tests.py
@@ -361,7 +361,7 @@ class DatasetsApiTests(APITestCase):
         f = open(self.exml_path, "r")
         put_data = {"metadata_file": f}
         response = self.client.put(url, data=put_data)
-        self.assertEqual(500, response.status_code)
+        self.assertEqual(200, response.status_code)
 
     def test_permissions_for_not_permitted_user(self):
         get_user_model().objects.create_user(

--- a/geonode/layers/api/views.py
+++ b/geonode/layers/api/views.py
@@ -147,7 +147,7 @@ class DatasetViewSet(DynamicModelViewSet):
             except Exception:
                 raise GeneralDatasetException(detail="Failed to update metadata")
             out["success"] = True
-            out_message = 'Metadata successfully updated'
+            out_message = "Metadata successfully updated"
             if dataset_uuid and dataset.uuid != dataset_uuid:
                 out_message += " The UUID identifier from the XML Metadata is different from the one saved"
             out["message"] = [out_message]

--- a/geonode/layers/api/views.py
+++ b/geonode/layers/api/views.py
@@ -141,17 +141,16 @@ class DatasetViewSet(DynamicModelViewSet):
                 dataset_uuid, vals, regions, keywords, _ = parse_metadata(open(metadata_file).read())
             except Exception:
                 raise InvalidMetadataException(detail="Unsupported metadata format")
-            if dataset_uuid and dataset.uuid != dataset_uuid:
-                raise InvalidMetadataException(
-                    detail="The UUID identifier from the XML Metadata, is different from the one saved"
-                )
             try:
                 updated_dataset = update_resource(dataset, metadata_file, regions, keywords, vals)
                 updated_dataset.save()  # This also triggers the recreation of the XML metadata file according to the updated values
             except Exception:
                 raise GeneralDatasetException(detail="Failed to update metadata")
             out["success"] = True
-            out["message"] = ["Metadata successfully updated"]
+            out_message = 'Metadata successfully updated'
+            if dataset_uuid and dataset.uuid != dataset_uuid:
+                out_message += " The UUID identifier from the XML Metadata is different from the one saved"
+            out["message"] = [out_message]
             return Response(out)
         except Exception as e:
             raise e

--- a/geonode/layers/templates/datasets/dataset_metadata_upload.html
+++ b/geonode/layers/templates/datasets/dataset_metadata_upload.html
@@ -63,6 +63,7 @@
     </section>
 
     <section>
+      <div class="btn-danger"><strong>{% trans "WARNING" %}: </strong>{% trans "This will most probably overwrite the current metadata!" %}</div>
       <a href="{% url "dataset_metadata_upload" resource.alternate %}" id="clear-button" class="btn btn-default">{% trans "Clear" %}</a>
       <a href="#" id="upload-button" class="btn btn-primary">{% trans "Upload files" %}</a>
     </section>

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1005,7 +1005,8 @@ class DatasetsTest(GeoNodeBaseTestSupport):
         resp = self.client.post(reverse("dataset_upload"), params)
         self.assertEqual(200, resp.status_code)
         self.assertEqual(
-            resp.json()["warning"], "WARNING: The XML's UUID was ignored while updating this dataset's metadata because that UUID is already present in this system. The rest of the XML's metadata was applied."
+            resp.json()["warning"],
+            "WARNING: The XML's UUID was ignored while updating this dataset's metadata because that UUID is already present in this system. The rest of the XML's metadata was applied.",
         )
 
     def test_sld_should_raise_500_if_is_invalid(self):
@@ -1053,7 +1054,7 @@ class DatasetsTest(GeoNodeBaseTestSupport):
         self.assertIsNotNone(updated_dataset.styles.first())
         self.assertEqual(layer.styles.first().sld_title, updated_dataset.styles.first().sld_title)
 
-    def test_xml_should_raise_an_error_if_the_uuid_is_changed(self):
+    def test_xml_should_not_raise_an_error_if_the_uuid_is_changed(self):
         """
         If the UUID coming from the XML and the one saved in the DB are different
         The system should not raise an error, instead it should simply update the values
@@ -1073,11 +1074,10 @@ class DatasetsTest(GeoNodeBaseTestSupport):
         self.assertEqual(0, prev_dataset.keywords.count())
         resp = self.client.post(reverse("dataset_upload"), params)
         self.assertEqual(200, resp.status_code)
-        expected = {
-            "success": True,
-            "warning": "WARNING: The XML's UUID was ignored while updating this dataset's metadata because that UUID is already present in this system. The rest of the XML's metadata was applied.",
-        }
-        self.assertDictEqual(expected, resp.json())
+        self.assertEqual(
+            resp.json()["warning"],
+            "WARNING: The XML's UUID was ignored while updating this dataset's metadata because that UUID is already present in this system. The rest of the XML's metadata was applied.",
+        )
 
     def test_will_raise_exception_for_replace_vector_dataset_with_raster(self):
         layer = Dataset.objects.get(name="single_point")

--- a/geonode/layers/tests.py
+++ b/geonode/layers/tests.py
@@ -1003,9 +1003,9 @@ class DatasetsTest(GeoNodeBaseTestSupport):
         prev_dataset = Dataset.objects.get(typename="geonode:single_point")
         self.assertEqual(0, prev_dataset.keywords.count())
         resp = self.client.post(reverse("dataset_upload"), params)
-        self.assertEqual(404, resp.status_code)
+        self.assertEqual(200, resp.status_code)
         self.assertEqual(
-            resp.json()["errors"], "The UUID identifier from the XML Metadata, is different from the one saved"
+            resp.json()["warning"], "WARNING: The XML's UUID was ignored while updating this dataset's metadata because that UUID is already present in this system. The rest of the XML's metadata was applied."
         )
 
     def test_sld_should_raise_500_if_is_invalid(self):
@@ -1056,7 +1056,7 @@ class DatasetsTest(GeoNodeBaseTestSupport):
     def test_xml_should_raise_an_error_if_the_uuid_is_changed(self):
         """
         If the UUID coming from the XML and the one saved in the DB are different
-        The system should raise an error
+        The system should not raise an error, instead it should simply update the values
         """
         params = {
             "permissions": '{ "users": {"AnonymousUser": ["view_resourcebase"]} , "groups":{}}',
@@ -1072,10 +1072,10 @@ class DatasetsTest(GeoNodeBaseTestSupport):
         prev_dataset = Dataset.objects.get(typename="geonode:single_point")
         self.assertEqual(0, prev_dataset.keywords.count())
         resp = self.client.post(reverse("dataset_upload"), params)
-        self.assertEqual(404, resp.status_code)
+        self.assertEqual(200, resp.status_code)
         expected = {
-            "success": False,
-            "errors": "The UUID identifier from the XML Metadata, is different from the one saved",
+            "success": True,
+            "warning": "WARNING: The XML's UUID was ignored while updating this dataset's metadata because that UUID is already present in this system. The rest of the XML's metadata was applied.",
         }
         self.assertDictEqual(expected, resp.json())
 

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -185,7 +185,9 @@ def dataset_upload_metadata(request):
             out["success"] = True
             status_code = 200
             if dataset_uuid and layer.uuid != dataset_uuid:
-                out["warning"] = "WARNING: The XML's UUID was ignored while updating this dataset's metadata because that UUID is already present in this system. The rest of the XML's metadata was applied."
+                out[
+                    "warning"
+                ] = "WARNING: The XML's UUID was ignored while updating this dataset's metadata because that UUID is already present in this system. The rest of the XML's metadata was applied."
             return HttpResponse(json.dumps(out), content_type="application/json", status=status_code)
 
         else:

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -183,11 +183,9 @@ def dataset_upload_metadata(request):
                 upload_session.processed = True
                 upload_session.save()
             out["success"] = True
+            status_code = 200
             if dataset_uuid and layer.uuid != dataset_uuid:
-                status_code = 199
-                out["errors"] = "WARNING: UUID of dataset and metadata are different. Metadata XML was still uploaded"
-            else:
-                status_code = 200
+                out["warning"] = "WARNING: UUID of dataset and metadata are different. Metadata XML was still uploaded"
             return HttpResponse(json.dumps(out), content_type="application/json", status=status_code)
 
         else:

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -185,7 +185,7 @@ def dataset_upload_metadata(request):
             out["success"] = True
             status_code = 200
             if dataset_uuid and layer.uuid != dataset_uuid:
-                out["warning"] = "WARNING: UUID of dataset and metadata are different. Metadata XML was still uploaded"
+                out["warning"] = "WARNING: The XML's UUID was ignored while updating this dataset's metadata because that UUID is already present in this system. The rest of the XML's metadata was applied."
             return HttpResponse(json.dumps(out), content_type="application/json", status=status_code)
 
         else:

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -171,10 +171,6 @@ def dataset_upload_metadata(request):
         )
         if layer:
             dataset_uuid, vals, regions, keywords, _ = parse_metadata(open(base_file).read())
-            if dataset_uuid and layer.uuid != dataset_uuid:
-                out["success"] = False
-                out["errors"] = "The UUID identifier from the XML Metadata, is different from the one saved"
-                return HttpResponse(json.dumps(out), content_type="application/json", status=404)
             updated_dataset = update_resource(layer, base_file, regions, keywords, vals)
             updated_dataset.save()
             out["status"] = ["finished"]
@@ -186,9 +182,14 @@ def dataset_upload_metadata(request):
                 upload_session = updated_dataset.upload_session
                 upload_session.processed = True
                 upload_session.save()
-            status_code = 200
             out["success"] = True
+            if dataset_uuid and layer.uuid != dataset_uuid:
+                status_code = 199
+                out["errors"] = "WARNING: UUID of dataset and metadata are different. Metadata XML was still uploaded"
+            else:
+                status_code = 200
             return HttpResponse(json.dumps(out), content_type="application/json", status=status_code)
+
         else:
             out["success"] = False
             out["errors"] = "Dataset selected does not exists"

--- a/geonode/locale/en/LC_MESSAGES/django.po
+++ b/geonode/locale/en/LC_MESSAGES/django.po
@@ -1168,6 +1168,9 @@ msgstr "Files to be uploaded"
 msgid "Is Upload Metadata XML Form"
 msgstr "Is Upload Metadata XML Form"
 
+msgid "This will most probably overwrite the current metadata!"
+msgstr "This will most probably overwrite the current metadata!"
+
 msgid "Upload files"
 msgstr "Upload files"
 

--- a/geonode/static/geonode/js/upload/LayerInfo.js
+++ b/geonode/static/geonode/js/upload/LayerInfo.js
@@ -458,7 +458,15 @@ define(function (require, exports) {
         } catch (err) {
             // pass
         }
-        var info_message = gettext('Your ' + resourceType +' was successfully created.');
+        var info_message = ''
+        var level = 'alert-success'
+        if (resp.warning){
+            info_message = resp.warning
+            level = 'alert-warning'
+        }
+        else{
+            info_message = gettext('Your ' + resourceType +' was successfully created.');
+        }
         var a = '<a href="' + resp.url + '" class="btn btn-success">' + gettext(resourceType.capitalize() + ' Info') + '</a>&nbsp;&nbsp;&nbsp;';
         if(resourceType == 'dataset') {
             // Only Layers have Metadata and SLD Upload features for the moment
@@ -474,7 +482,7 @@ define(function (require, exports) {
         }
         self.logStatus({
             msg: '<p>' + info_message + '<br/>' + msg_col + '<br/>' + a + '</p>',
-            level: 'alert-success',
+            level: level,
             empty: 'true'
         });
     };
@@ -568,6 +576,7 @@ define(function (require, exports) {
             callback(array);
         } else if (resp.success === true) {
             self.polling = false;
+            console.log(resp)
             self.displayUploadedLayerLinks(resp);
 
             callback(array);

--- a/geonode/static/geonode/js/upload/LayerInfo.js
+++ b/geonode/static/geonode/js/upload/LayerInfo.js
@@ -576,7 +576,6 @@ define(function (require, exports) {
             callback(array);
         } else if (resp.success === true) {
             self.polling = false;
-            console.log(resp)
             self.displayUploadedLayerLinks(resp);
 
             callback(array);


### PR DESCRIPTION
@dorohahn create a PR against our main development line (`thuenen_4.x` in case of the GeoNode fork) as I do here:

![image](https://github.com/Thuenen-GeoNode-Development/geonode/assets/881756/06e4ad07-b576-4ab1-9906-c783a665e7d8)

Please also link to the actual issue:

Resolves: https://github.com/Thuenen-GeoNode-Development/Sprints/issues/7