### PR TITLE
Fixes wrong mapping to the download links

### DIFF
--- a/geonode/catalogue/backends/pycsw_local_mappings.py
+++ b/geonode/catalogue/backends/pycsw_local_mappings.py
@@ -86,6 +86,6 @@ MD_CORE_MODEL = {
         "pycsw:Publisher": "publisher",
         "pycsw:Contributor": "contributor",
         "pycsw:Relation": "relation",
-        "pycsw:Links": "download_urls",
+        "pycsw:Links": "download_links",
     },
 }


### PR DESCRIPTION
Closes: https://github.com/Thuenen-GeoNode-Development/thuenen_atlas/issues/21
See also: https://github.com/GeoNode/geonode-mapstore-client/issues/1703