### PR TITLE
fix api permissions

### DIFF
--- a/geonode/documents/api/views.py
+++ b/geonode/documents/api/views.py
@@ -131,7 +131,7 @@ class DocumentViewSet(ApiPresetsInitializer, DynamicModelViewSet, AdvertisedList
 
             resource.set_missing_info()
             resourcebase_post_save(resource.get_real_instance())
-            resource_manager.set_permissions(None, instance=resource, permissions=None, created=True)
+            resource.set_default_permissions(owner=self.request.user, created=True)
             resource.handle_moderated_uploads()
             resource_manager.set_thumbnail(resource.uuid, instance=resource, overwrite=False)
             return resource

--- a/geonode/documents/views.py
+++ b/geonode/documents/views.py
@@ -189,10 +189,7 @@ class DocumentUploadView(CreateView):
             )
 
         self.object.handle_moderated_uploads()
-        resource_manager.set_permissions(
-            None, instance=self.object, permissions=form.cleaned_data["permissions"], created=True
-        )
-
+        self.object.set_default_permissions(owner=self.request.user, created=True)
         abstract = None
         date = None
         regions = []


### PR DESCRIPTION
Aims to resolve 
[#12616](https://github.com/GeoNode/geonode/issues/12616) and [#35](https://github.com/Thuenen-GeoNode-Development/thuenen_atlas/issues/35)

It seems like the problem was that permissions were assigned to None both when handling UI and API document upload. On UI it didn't cause a problem because in UI upload there is also a call setting permissions to defaults again. 